### PR TITLE
Add department filter support to search requests

### DIFF
--- a/src/main/java/uos/aloc/scholar/search/dto/SearchRequestDTO.java
+++ b/src/main/java/uos/aloc/scholar/search/dto/SearchRequestDTO.java
@@ -1,13 +1,18 @@
 package uos.aloc.scholar.search.dto;
 
-import uos.aloc.scholar.crawler.entity.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import uos.aloc.scholar.crawler.entity.NoticeCategory;
+import uos.aloc.scholar.search.filter.DepartmentFilterRegistry;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -20,23 +25,118 @@ public class SearchRequestDTO {
     // 추가: 지정한 카테고리만 사용할지 여부 (기본 false: ACADEMIC/GENERAL 자동 포함)
     private boolean exact = false;
 
+    @Setter(AccessLevel.NONE)
+    private List<String> departments = new ArrayList<>();
+
+    public void setDepartments(List<String> departments) {
+        this.departments = sanitizeDepartments(departments);
+    }
+
+    public void setDepartment(List<String> departments) {
+        setDepartments(departments);
+    }
+
+    public void setDepartment(String departmentsCsv) {
+        if (departmentsCsv == null) {
+            this.departments = new ArrayList<>();
+            return;
+        }
+        List<String> parsed = Arrays.stream(departmentsCsv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toCollection(ArrayList::new));
+        setDepartments(parsed);
+    }
+
     public List<NoticeCategory> effectiveCategories() {
+        return computeEffectiveCategories(null);
+    }
+
+    public List<NoticeCategory> effectiveCategories(DepartmentFilterRegistry registry) {
+        if (registry == null) {
+            return effectiveCategories();
+        }
+
+        List<String> sanitizedDepartments = currentDepartments();
+        if (sanitizedDepartments.isEmpty()) {
+            return effectiveCategories();
+        }
+
+        Set<NoticeCategory> fromRegistry = new LinkedHashSet<>();
+        for (String dept : sanitizedDepartments) {
+            Optional<DepartmentFilterRegistry.DepartmentFilter> filter = registry.find(dept);
+            filter.ifPresent(f -> fromRegistry.addAll(f.categories()));
+        }
+
+        if (fromRegistry.isEmpty()) {
+            return effectiveCategories();
+        }
+
+        return computeEffectiveCategories(fromRegistry);
+    }
+
+    public String normalizedKeyword() {
+        return keyword == null ? "" : keyword.trim();
+    }
+
+    public List<String> resolvedDeptAliases(DepartmentFilterRegistry registry) {
+        List<String> sanitizedDepartments = currentDepartments();
+        if (sanitizedDepartments.isEmpty() || registry == null) {
+            return sanitizedDepartments;
+        }
+
+        List<String> resolved = new ArrayList<>();
+        for (String dept : sanitizedDepartments) {
+            Optional<DepartmentFilterRegistry.DepartmentFilter> filter = registry.find(dept);
+            resolved.add(filter.map(DepartmentFilterRegistry.DepartmentFilter::canonicalAlias).orElse(dept));
+        }
+        return resolved;
+    }
+
+    private List<NoticeCategory> computeEffectiveCategories(Set<NoticeCategory> base) {
         if (exact) {
-            // exact=true면 사용자가 준 카테고리만 사용 (없으면 학사만 기본값으로)
+            if (base != null && !base.isEmpty()) {
+                return new ArrayList<>(base);
+            }
             if (category == null || category.isEmpty()) {
                 return List.of(NoticeCategory.ACADEMIC);
             }
             return new ArrayList<>(new LinkedHashSet<>(category));
         }
-        // 기본 동작: 선택 + ACADEMIC + GENERAL 합집합
+
         Set<NoticeCategory> set = new LinkedHashSet<>();
         set.add(NoticeCategory.ACADEMIC);
         set.add(NoticeCategory.GENERAL);
-        if (category != null) set.addAll(category);
+        if (base != null) {
+            set.addAll(base);
+        }
+        if (category != null) {
+            set.addAll(category);
+        }
         return new ArrayList<>(set);
     }
 
-    public String normalizedKeyword() {
-        return keyword == null ? "" : keyword.trim();
+    private static List<String> sanitizeDepartments(List<String> source) {
+        if (source == null || source.isEmpty()) {
+            return new ArrayList<>();
+        }
+        Set<String> unique = new LinkedHashSet<>();
+        for (String value : source) {
+            if (value == null) {
+                continue;
+            }
+            String trimmed = value.trim();
+            if (!trimmed.isEmpty()) {
+                unique.add(trimmed);
+            }
+        }
+        return new ArrayList<>(unique);
+    }
+
+    private List<String> currentDepartments() {
+        if (departments == null || departments.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return new ArrayList<>(departments);
     }
 }

--- a/src/main/java/uos/aloc/scholar/search/filter/DepartmentFilterRegistry.java
+++ b/src/main/java/uos/aloc/scholar/search/filter/DepartmentFilterRegistry.java
@@ -1,0 +1,17 @@
+package uos.aloc.scholar.search.filter;
+
+import uos.aloc.scholar.crawler.entity.NoticeCategory;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public interface DepartmentFilterRegistry {
+
+    Optional<DepartmentFilter> find(String department);
+
+    interface DepartmentFilter {
+        String canonicalAlias();
+
+        Collection<NoticeCategory> categories();
+    }
+}


### PR DESCRIPTION
## Summary
- add a departments field on `SearchRequestDTO` with CSV parsing that skips blank entries
- implement registry-aware helpers for resolving categories and department aliases
- introduce a `DepartmentFilterRegistry` interface to support the new helpers

## Testing
- ./gradlew test *(fails: Gradle could not locate a Java 17 toolchain in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e21baca25c8325a941654737642d62