### PR TITLE
Refine notice search filters

### DIFF
--- a/src/main/java/uos/aloc/scholar/search/config/DepartmentFilterRegistry.java
+++ b/src/main/java/uos/aloc/scholar/search/config/DepartmentFilterRegistry.java
@@ -1,0 +1,331 @@
+package uos.aloc.scholar.search.config;
+
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+import uos.aloc.scholar.crawler.entity.NoticeCategory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+public class DepartmentFilterRegistry {
+
+    private static final String YAML_DATA = """
+국어국문학과:
+  category: COLLEGE_HUMANITIES
+  aliases:
+    - 국문학과
+    - 국문과
+영어영문학과:
+  category: COLLEGE_HUMANITIES
+  aliases:
+    - 영어영문과
+    - 영문과
+    - 영어과
+중국어문화학과:
+  category: COLLEGE_HUMANITIES
+  aliases:
+    - 중국어과
+    - 중문과
+국사학과:
+  category: COLLEGE_HUMANITIES
+  aliases:
+    - 역사학과
+    - 한국사학과
+철학과:
+  category: COLLEGE_HUMANITIES
+  aliases:
+    - 철학전공
+    - 철학학과
+경제학부:
+  category: COLLEGE_SOCIAL_SCIENCES
+  aliases:
+    - 경제학과
+    - 경제과
+    - 경제전공
+사회복지학과:
+  category: COLLEGE_SOCIAL_SCIENCES
+  aliases:
+    - 사회복지과
+    - 복지학과
+사회학과:
+  category: COLLEGE_SOCIAL_SCIENCES
+  aliases:
+    - 사회과
+    - 사회전공
+국제관계학과:
+  category: COLLEGE_SOCIAL_SCIENCES
+  aliases:
+    - 국제관계과
+    - 국제정치학과
+정치외교학과:
+  category: COLLEGE_SOCIAL_SCIENCES
+  aliases:
+    - 정치외교과
+    - 정치학과
+    - 외교학과
+행정학과:
+  category: COLLEGE_SOCIAL_SCIENCES
+  aliases:
+    - 행정과
+    - 공공행정학과
+도시사회학과:
+  category: COLLEGE_SOCIAL_SCIENCES
+  aliases:
+    - 도시사회과
+도시행정학과:
+  category: COLLEGE_SOCIAL_SCIENCES
+  aliases:
+    - 도시행정과
+경영학부:
+  category: COLLEGE_BUSINESS
+  aliases:
+    - 경영학과
+    - 경영과
+    - 경영전공
+세무학과:
+  category: COLLEGE_BUSINESS
+  aliases:
+    - 세무과
+    - 세무전공
+수학과:
+  category: COLLEGE_NATURAL_SCIENCES
+  aliases:
+    - 수리과학과
+통계학과:
+  category: COLLEGE_NATURAL_SCIENCES
+  aliases:
+    - 통계과
+    - 통계전공
+물리학과:
+  category: COLLEGE_NATURAL_SCIENCES
+  aliases:
+    - 물리과
+화학과:
+  category: COLLEGE_NATURAL_SCIENCES
+  aliases:
+    - 화학전공
+생명과학과:
+  category: COLLEGE_NATURAL_SCIENCES
+  aliases:
+    - 생명과
+    - 생명과학전공
+기계정보공학과:
+  category: COLLEGE_ENGINEERING
+  aliases:
+    - 기계정보과
+    - 기계공학과
+신소재공학과:
+  category: COLLEGE_ENGINEERING
+  aliases:
+    - 신소재과
+    - 신소재전공
+전자전기컴퓨터공학부:
+  category: COLLEGE_ENGINEERING
+  aliases:
+    - 전자전기공학부
+    - 전자공학과
+    - 전기공학과
+    - 컴퓨터공학과
+    - 컴퓨터과학부
+화학공학과:
+  category: COLLEGE_ENGINEERING
+  aliases:
+    - 화공과
+    - 화공생명공학과
+건설시스템공학과:
+  category: COLLEGE_ENGINEERING
+  aliases:
+    - 건설시스템과
+    - 건설공학과
+건축학부(건축학):
+  category: COLLEGE_URBAN_SCIENCE
+  aliases:
+    - 건축학부
+    - 건축학과
+건축학부(건축공학):
+  category: COLLEGE_URBAN_SCIENCE
+  aliases:
+    - 건축공학과
+토목공학과:
+  category: COLLEGE_URBAN_SCIENCE
+  aliases:
+    - 토목과
+도시공학과:
+  category: COLLEGE_URBAN_SCIENCE
+  aliases:
+    - 도시계획과
+    - 도시계획학과
+교통공학과:
+  category: COLLEGE_URBAN_SCIENCE
+  aliases:
+    - 교통과
+    - 교통전공
+환경공학부:
+  category: COLLEGE_URBAN_SCIENCE
+  aliases:
+    - 환경공학과
+    - 환경과
+공간정보공학과:
+  category: COLLEGE_URBAN_SCIENCE
+  aliases:
+    - 공간정보과
+    - 측량학과
+    - 지적학과
+조경학과:
+  category: COLLEGE_URBAN_SCIENCE
+  aliases:
+    - 조경과
+부동산학과:
+  category: COLLEGE_URBAN_SCIENCE
+  aliases:
+    - 부동산과
+도시사회학과(도시과학대학):
+  category: COLLEGE_URBAN_SCIENCE
+  aliases:
+    - 도시사회학전공
+산업디자인학과:
+  category: COLLEGE_ARTS_SPORTS
+  aliases:
+    - 디자인학부(산업디자인)
+    - 산업디자인전공
+도시공간디자인학과:
+  category: COLLEGE_ARTS_SPORTS
+  aliases:
+    - 디자인학부(도시공간디자인)
+환경조각학과:
+  category: COLLEGE_ARTS_SPORTS
+  aliases:
+    - 환경조각과
+음악학과:
+  category: COLLEGE_ARTS_SPORTS
+  aliases:
+    - 음악과
+    - 성악과
+스포츠과학과:
+  category: COLLEGE_ARTS_SPORTS
+  aliases:
+    - 체육학과
+    - 체육과
+    - 스포츠과
+자유전공학부:
+  category: COLLEGE_LIBERAL_CONVERGENCE
+  aliases:
+    - 자유전공
+    - 자율전공학부
+데이터사이언스학과:
+  category: COLLEGE_LIBERAL_CONVERGENCE
+  aliases:
+    - 데이터사이언스과
+    - 데이터과학과
+인공지능학과:
+  category: COLLEGE_LIBERAL_CONVERGENCE
+  aliases:
+    - AI학과
+    - 인공지능과
+스마트시티융합학과:
+  category: COLLEGE_LIBERAL_CONVERGENCE
+  aliases:
+    - 스마트시티학과
+    - 스마트도시학과
+""";
+
+    private final Map<String, DepartmentMeta> metaByDepartment;
+    private final Map<String, String> aliasIndex;
+
+    public DepartmentFilterRegistry() {
+        this.metaByDepartment = Collections.unmodifiableMap(loadYaml());
+        this.aliasIndex = Collections.unmodifiableMap(buildAliasIndex(metaByDepartment));
+    }
+
+    private Map<String, DepartmentMeta> loadYaml() {
+        Yaml yaml = new Yaml();
+        Map<String, Object> loaded = yaml.load(YAML_DATA);
+        Map<String, DepartmentMeta> map = new LinkedHashMap<>();
+        if (loaded == null) {
+            return map;
+        }
+        for (Map.Entry<String, Object> entry : loaded.entrySet()) {
+            Object value = entry.getValue();
+            if (!(value instanceof Map<?, ?> entryMap)) {
+                continue;
+            }
+            String categoryName = Objects.toString(entryMap.get("category"), null);
+            if (categoryName == null) {
+                continue;
+            }
+            NoticeCategory category = NoticeCategory.valueOf(categoryName);
+            List<String> aliases = new ArrayList<>();
+            Object aliasObj = entryMap.get("aliases");
+            if (aliasObj instanceof Iterable<?> iterable) {
+                for (Object item : iterable) {
+                    if (item != null) {
+                        aliases.add(item.toString());
+                    }
+                }
+            }
+            map.put(entry.getKey(), new DepartmentMeta(category, aliases));
+        }
+        return map;
+    }
+
+    private Map<String, String> buildAliasIndex(Map<String, DepartmentMeta> map) {
+        Map<String, String> index = new HashMap<>();
+        map.forEach((department, meta) -> {
+            index.put(department, department);
+            for (String alias : meta.aliases()) {
+                index.putIfAbsent(alias, department);
+            }
+        });
+        return index;
+    }
+
+    public Optional<DepartmentMeta> getMeta(String name) {
+        return findCanonicalName(name).map(metaByDepartment::get);
+    }
+
+    public boolean contains(String name) {
+        return findCanonicalName(name).isPresent();
+    }
+
+    public Optional<String> findCanonicalName(String name) {
+        if (name == null) {
+            return Optional.empty();
+        }
+        String normalized = name.trim();
+        if (normalized.isEmpty()) {
+            return Optional.empty();
+        }
+        String canonical = aliasIndex.get(normalized);
+        if (canonical != null) {
+            return Optional.of(canonical);
+        }
+        return Optional.ofNullable(metaByDepartment.containsKey(normalized) ? normalized : null);
+    }
+
+    public Optional<NoticeCategory> lookupCategory(String name) {
+        return getMeta(name).map(DepartmentMeta::category);
+    }
+
+    public Set<String> departments() {
+        return metaByDepartment.keySet();
+    }
+
+    public Map<String, DepartmentMeta> asMap() {
+        return metaByDepartment;
+    }
+
+    public record DepartmentMeta(NoticeCategory category, List<String> aliases) {
+        public DepartmentMeta {
+            category = Objects.requireNonNull(category, "category");
+            aliases = aliases == null ? List.of() : List.copyOf(aliases);
+        }
+    }
+}

--- a/src/main/java/uos/aloc/scholar/search/dto/NoticeResponseDTO.java
+++ b/src/main/java/uos/aloc/scholar/search/dto/NoticeResponseDTO.java
@@ -29,4 +29,20 @@ public class NoticeResponseDTO {
                 .viewCount(n.getViewCount())
                 .build();
     }
+
+    public NoticeResponseDTO(Long id,
+                             String title,
+                             LocalDate postedDate,
+                             String department,
+                             String link,
+                             NoticeCategory category,
+                             Integer viewCount) {
+        this(id,
+                title,
+                postedDate,
+                department,
+                link,
+                category != null ? category.name() : null,
+                viewCount);
+    }
 }

--- a/src/main/java/uos/aloc/scholar/search/dto/SearchRequestDTO.java
+++ b/src/main/java/uos/aloc/scholar/search/dto/SearchRequestDTO.java
@@ -1,6 +1,7 @@
 package uos.aloc.scholar.search.dto;
 
 import uos.aloc.scholar.crawler.entity.*;
+import uos.aloc.scholar.search.service.DepartmentFilterRegistry;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,6 +15,7 @@ import java.util.Set;
 public class SearchRequestDTO {
     private String keyword = "";
     private List<NoticeCategory> category = new ArrayList<>();
+    private List<String> department = new ArrayList<>();
     private int page = 0;
     private int size = 15;
 
@@ -38,5 +40,12 @@ public class SearchRequestDTO {
 
     public String normalizedKeyword() {
         return keyword == null ? "" : keyword.trim();
+    }
+
+    public List<String> departmentAliases(DepartmentFilterRegistry registry) {
+        if (registry == null) {
+            return List.of();
+        }
+        return registry.resolveAliases(department);
     }
 }

--- a/src/main/java/uos/aloc/scholar/search/dto/SearchRequestDTO.java
+++ b/src/main/java/uos/aloc/scholar/search/dto/SearchRequestDTO.java
@@ -2,13 +2,19 @@ package uos.aloc.scholar.search.dto;
 
 import uos.aloc.scholar.crawler.entity.*;
 import uos.aloc.scholar.search.service.DepartmentFilterRegistry;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import uos.aloc.scholar.crawler.entity.NoticeCategory;
+import uos.aloc.scholar.search.filter.DepartmentFilterRegistry;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -22,24 +28,119 @@ public class SearchRequestDTO {
     // 추가: 지정한 카테고리만 사용할지 여부 (기본 false: ACADEMIC/GENERAL 자동 포함)
     private boolean exact = false;
 
+    @Setter(AccessLevel.NONE)
+    private List<String> departments = new ArrayList<>();
+
+    public void setDepartments(List<String> departments) {
+        this.departments = sanitizeDepartments(departments);
+    }
+
+    public void setDepartment(List<String> departments) {
+        setDepartments(departments);
+    }
+
+    public void setDepartment(String departmentsCsv) {
+        if (departmentsCsv == null) {
+            this.departments = new ArrayList<>();
+            return;
+        }
+        List<String> parsed = Arrays.stream(departmentsCsv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toCollection(ArrayList::new));
+        setDepartments(parsed);
+    }
+
     public List<NoticeCategory> effectiveCategories() {
+        return computeEffectiveCategories(null);
+    }
+
+    public List<NoticeCategory> effectiveCategories(DepartmentFilterRegistry registry) {
+        if (registry == null) {
+            return effectiveCategories();
+        }
+
+        List<String> sanitizedDepartments = currentDepartments();
+        if (sanitizedDepartments.isEmpty()) {
+            return effectiveCategories();
+        }
+
+        Set<NoticeCategory> fromRegistry = new LinkedHashSet<>();
+        for (String dept : sanitizedDepartments) {
+            Optional<DepartmentFilterRegistry.DepartmentFilter> filter = registry.find(dept);
+            filter.ifPresent(f -> fromRegistry.addAll(f.categories()));
+        }
+
+        if (fromRegistry.isEmpty()) {
+            return effectiveCategories();
+        }
+
+        return computeEffectiveCategories(fromRegistry);
+    }
+
+    public String normalizedKeyword() {
+        return keyword == null ? "" : keyword.trim();
+    }
+
+    public List<String> resolvedDeptAliases(DepartmentFilterRegistry registry) {
+        List<String> sanitizedDepartments = currentDepartments();
+        if (sanitizedDepartments.isEmpty() || registry == null) {
+            return sanitizedDepartments;
+        }
+
+        List<String> resolved = new ArrayList<>();
+        for (String dept : sanitizedDepartments) {
+            Optional<DepartmentFilterRegistry.DepartmentFilter> filter = registry.find(dept);
+            resolved.add(filter.map(DepartmentFilterRegistry.DepartmentFilter::canonicalAlias).orElse(dept));
+        }
+        return resolved;
+    }
+
+    private List<NoticeCategory> computeEffectiveCategories(Set<NoticeCategory> base) {
         if (exact) {
-            // exact=true면 사용자가 준 카테고리만 사용 (없으면 학사만 기본값으로)
+            if (base != null && !base.isEmpty()) {
+                return new ArrayList<>(base);
+            }
             if (category == null || category.isEmpty()) {
                 return List.of(NoticeCategory.ACADEMIC);
             }
             return new ArrayList<>(new LinkedHashSet<>(category));
         }
-        // 기본 동작: 선택 + ACADEMIC + GENERAL 합집합
+
         Set<NoticeCategory> set = new LinkedHashSet<>();
         set.add(NoticeCategory.ACADEMIC);
         set.add(NoticeCategory.GENERAL);
-        if (category != null) set.addAll(category);
+        if (base != null) {
+            set.addAll(base);
+        }
+        if (category != null) {
+            set.addAll(category);
+        }
         return new ArrayList<>(set);
     }
 
-    public String normalizedKeyword() {
-        return keyword == null ? "" : keyword.trim();
+    private static List<String> sanitizeDepartments(List<String> source) {
+        if (source == null || source.isEmpty()) {
+            return new ArrayList<>();
+        }
+        Set<String> unique = new LinkedHashSet<>();
+        for (String value : source) {
+            if (value == null) {
+                continue;
+            }
+            String trimmed = value.trim();
+            if (!trimmed.isEmpty()) {
+                unique.add(trimmed);
+            }
+        }
+        return new ArrayList<>(unique);
+    }
+
+    private List<String> currentDepartments() {
+        if (departments == null || departments.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return new ArrayList<>(departments);
     }
 
     public List<String> departmentAliases(DepartmentFilterRegistry registry) {

--- a/src/main/java/uos/aloc/scholar/search/filter/DepartmentFilterRegistry.java
+++ b/src/main/java/uos/aloc/scholar/search/filter/DepartmentFilterRegistry.java
@@ -1,0 +1,17 @@
+package uos.aloc.scholar.search.filter;
+
+import uos.aloc.scholar.crawler.entity.NoticeCategory;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public interface DepartmentFilterRegistry {
+
+    Optional<DepartmentFilter> find(String department);
+
+    interface DepartmentFilter {
+        String canonicalAlias();
+
+        Collection<NoticeCategory> categories();
+    }
+}

--- a/src/main/java/uos/aloc/scholar/search/repository/NoticeSearchRepository.java
+++ b/src/main/java/uos/aloc/scholar/search/repository/NoticeSearchRepository.java
@@ -1,6 +1,7 @@
 package uos.aloc.scholar.search.repository;
 
-import uos.aloc.scholar.crawler.entity.*;        
+import uos.aloc.scholar.crawler.entity.*;
+import uos.aloc.scholar.search.dto.NoticeResponseDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.*;
@@ -12,20 +13,47 @@ import java.util.List;
 public interface NoticeSearchRepository extends JpaRepository<Notice, Long> {
 
     @Query("""
-        SELECT n
+        SELECT new uos.aloc.scholar.search.dto.NoticeResponseDTO(
+                n.id,
+                n.title,
+                n.postedDate,
+                n.department,
+                n.link,
+                n.category,
+                n.viewCount
+        )
           FROM Notice n
          WHERE n.category IN :categories
            AND (
+                 :deptSize = 0
+                 OR (n.department IS NOT NULL AND LOWER(n.department) IN :deptAliases)
+               )
+           AND (
                  :keyword IS NULL OR :keyword = ''
-                 OR n.title      LIKE CONCAT(CONCAT('%', :keyword, '%'))
-                 OR n.summary    LIKE CONCAT(CONCAT('%', :keyword, '%'))
-                 OR n.department LIKE CONCAT(CONCAT('%', :keyword, '%'))
+                 OR LOWER(n.title)      LIKE CONCAT('%', :keywordLower, '%')
+                 OR LOWER(n.summary)    LIKE CONCAT('%', :keywordLower, '%')
+                 OR LOWER(n.department) LIKE CONCAT('%', :keywordLower, '%')
                )
          ORDER BY n.postedDate DESC, n.id DESC
     """)
-    Page<Notice> search(@Param("keyword") String keyword,
-                        @Param("categories") List<NoticeCategory> categories,
-                        Pageable pageable);
+    Page<NoticeResponseDTO> search(@Param("keyword") String keyword,
+                                   @Param("keywordLower") String keywordLower,
+                                   @Param("categories") List<NoticeCategory> categories,
+                                   @Param("deptAliases") List<String> deptAliases,
+                                   @Param("deptSize") int deptSize,
+                                   Pageable pageable);
+
+    default Page<NoticeResponseDTO> search(String keyword,
+                                           String keywordLower,
+                                           List<NoticeCategory> categories,
+                                           List<String> deptAliases,
+                                           Pageable pageable) {
+        List<String> safeAliases = (deptAliases == null || deptAliases.isEmpty())
+                ? List.of()
+                : List.copyOf(deptAliases);
+        int deptSize = safeAliases.size();
+        return search(keyword, keywordLower, categories, safeAliases, deptSize, pageable);
+    }
 
     // ✅ HOT Top3 (단일 카테고리)
     List<Notice> findTop3ByCategoryAndPostedDateGreaterThanEqualOrderByViewCountDescPostedDateDesc(

--- a/src/main/java/uos/aloc/scholar/search/service/DepartmentFilterRegistry.java
+++ b/src/main/java/uos/aloc/scholar/search/service/DepartmentFilterRegistry.java
@@ -1,0 +1,59 @@
+package uos.aloc.scholar.search.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Component
+public class DepartmentFilterRegistry {
+
+    private final Map<String, List<String>> aliasMap = new ConcurrentHashMap<>();
+
+    public void register(String key, List<String> aliases) {
+        if (key == null) {
+            return;
+        }
+        String normalizedKey = normalize(key);
+        if (normalizedKey.isEmpty()) {
+            return;
+        }
+        aliasMap.put(normalizedKey, normalizeAliases(aliases));
+    }
+
+    public List<String> resolveAliases(Collection<String> keys) {
+        if (keys == null || keys.isEmpty()) {
+            return List.of();
+        }
+
+        return keys.stream()
+                .filter(Objects::nonNull)
+                .map(this::normalize)
+                .filter(s -> !s.isEmpty())
+                .flatMap(key -> aliasMap.getOrDefault(key, List.of(key)).stream())
+                .map(alias -> alias.toLowerCase(Locale.ROOT))
+                .distinct()
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private List<String> normalizeAliases(Collection<String> aliases) {
+        if (aliases == null || aliases.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return aliases.stream()
+                .filter(Objects::nonNull)
+                .map(this::normalize)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private String normalize(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/src/main/java/uos/aloc/scholar/search/service/NoticeSearchServiceImpl.java
+++ b/src/main/java/uos/aloc/scholar/search/service/NoticeSearchServiceImpl.java
@@ -1,5 +1,6 @@
 package uos.aloc.scholar.search.service;
 
+import uos.aloc.scholar.crawler.entity.NoticeCategory;
 import uos.aloc.scholar.search.dto.NoticeResponseDTO;
 import uos.aloc.scholar.search.dto.SearchRequestDTO;
 import uos.aloc.scholar.search.repository.NoticeSearchRepository;
@@ -8,11 +9,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Locale;
+
 @Service
 @RequiredArgsConstructor
 public class NoticeSearchServiceImpl implements NoticeSearchService {
 
     private final NoticeSearchRepository noticeSearchRepository;
+    private final DepartmentFilterRegistry departmentFilterRegistry;
 
     @Override
     public Page<NoticeResponseDTO> search(SearchRequestDTO req) {
@@ -21,8 +26,12 @@ public class NoticeSearchServiceImpl implements NoticeSearchService {
                 Math.max(1, req.getSize())
         );
 
+        String keyword = req.normalizedKeyword();
+        String keywordLower = keyword.toLowerCase(Locale.ROOT);
+        List<NoticeCategory> categories = req.effectiveCategories();
+        List<String> deptAliases = req.departmentAliases(departmentFilterRegistry);
+
         return noticeSearchRepository
-                .search(req.normalizedKeyword(), req.effectiveCategories(), pageable)
-                .map(NoticeResponseDTO::from);
+                .search(keyword, keywordLower, categories, deptAliases, pageable);
     }
 }


### PR DESCRIPTION
## Summary
- inject the DepartmentFilterRegistry into the search service so category and department filters are prepared via the DTO helpers before querying
- add a registry component and DTO helper to resolve department alias lists for repository calls
- project NoticeResponseDTOs directly from the JPQL search query with the new department filters and lower-cased keyword comparisons

## Testing
- ./gradlew test *(fails: Java 17 toolchain not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e21c8319688325a8f5891c4fe675f9